### PR TITLE
Sets mimetype for WARC properly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - openjdk7 # on was-robots1-prod
+  - openjdk8
 
 install:
   - mvn test-compile -DskipTests=true -Dmaven.javadoc.skip=true -B -V

--- a/src/edu/stanford/sulair/dlss/was/metadata/reader/WAReader.java
+++ b/src/edu/stanford/sulair/dlss/was/metadata/reader/WAReader.java
@@ -37,15 +37,14 @@ abstract public class WAReader implements IWAReader {
 		this.fileObj = fileObj;
 	}
 
-	/** Fills the basic information about the file such as: the size, 
+	/** Fills the basic information about the file such as: the size,
 	 * mimeType, and checksum.
 	 * @return MetadataRepository object with the basic information
 	 */
 	protected MetadataRepository fillBasicInformationFromFile() {
 		MetadataRepository metadataRepository = new MetadataRepository(fileObj);
 		metadataRepository.setSize(fileObj.length());
-		metadataRepository.setMimeType((new MimetypesFileTypeMap()
-				.getContentType(fileObj)).toString());
+		metadataRepository.setMimeType(getBasicInformationMimeType());
 		try {
 			metadataRepository.setChecksumMD5(computeChecksumMD5());
 			metadataRepository.setChecksumSHA1(computeChecksumSHA1());
@@ -60,6 +59,10 @@ abstract public class WAReader implements IWAReader {
 		return metadataRepository;
 	}
 
+	protected String getBasicInformationMimeType() {
+		return (new MimetypesFileTypeMap().getContentType(fileObj)).toString();
+	}
+
 	/**
 	 * Computes the MD5 hash for the file defined by file input stream
 	 * @param fis input stream for the file
@@ -68,7 +71,7 @@ abstract public class WAReader implements IWAReader {
 	private String computeChecksumMD5() throws java.io.IOException, NoSuchAlgorithmException{
 		FileInputStream fis = new FileInputStream(fileObj);
 		MessageDigest digest = MessageDigest.getInstance("MD5");
-		
+
 		byte[] bytesBuffer = new byte[1024];
 		int bytesRead = -1;
 		while ((bytesRead = fis.read(bytesBuffer)) != -1) {
@@ -77,8 +80,8 @@ abstract public class WAReader implements IWAReader {
 		fis.close();
 		return convertByteArrayToHexString(digest.digest());
 	}
-	
-	
+
+
 	/**
 	 * Converts the bytearray to String
 	 * @param arrayBytes
@@ -96,12 +99,12 @@ abstract public class WAReader implements IWAReader {
 	/**
 	 * @return String the checksum in MD5
 	 * @throws IOException
-	 * @throws NoSuchAlgorithmException 
+	 * @throws NoSuchAlgorithmException
 	 */
 	protected String computeChecksumSHA1() throws IOException, NoSuchAlgorithmException {
 		FileInputStream fis = new FileInputStream(fileObj);
 		MessageDigest digest = MessageDigest.getInstance("SHA-1");
-		
+
 		byte[] bytesBuffer = new byte[1024];
 		int bytesRead = -1;
 		while ((bytesRead = fis.read(bytesBuffer)) != -1) {

--- a/src/edu/stanford/sulair/dlss/was/metadata/reader/WarcReaderWrapper.java
+++ b/src/edu/stanford/sulair/dlss/was/metadata/reader/WarcReaderWrapper.java
@@ -20,10 +20,10 @@ import org.jwat.warc.WarcRecord;
 import edu.stanford.sulair.dlss.was.metadata.MetadataRepository;
 
 /**
- * WarcReaderWrapper is a wrapper for jwat package to read the Arc files. 
+ * WarcReaderWrapper is a wrapper for jwat package to read the Arc files.
  * Instead of reading the file content, the WarcReaderWrapper will read
  * the content and convert it into MetadataRepository output.
- * 
+ *
  * @author aalsum
  */
 public class WarcReaderWrapper extends WAReader {
@@ -75,6 +75,11 @@ public class WarcReaderWrapper extends WAReader {
 
 		fis.close();
 		return metadataRepository;
+	}
+
+	@Override
+	protected String getBasicInformationMimeType() {
+		return "application/warc";
 	}
 
 	private void fillPayloadString(MetadataRepository metadataRepository,

--- a/test/edu/stanford/sulair/dlss/was/metadata/reader/WarcReaderWrapperTest.java
+++ b/test/edu/stanford/sulair/dlss/was/metadata/reader/WarcReaderWrapperTest.java
@@ -20,20 +20,20 @@ public class WarcReaderWrapperTest {
 	}
 
 	@Test
-	public void testFillMetadataRepositoryFromFile() {		
+	public void testFillMetadataRepositoryFromFile() {
 		WarcReaderWrapper warcReader = new WarcReaderWrapper(warcFileName);
 		try {
 			MetadataRepository metadataRepo =  warcReader.fillMetadataRepositoryFromFile();
-	
+
 			assertTrue("WARC".equalsIgnoreCase(metadataRepo.getFileType()));
 			assertTrue("WARC-Test.warc.gz".equalsIgnoreCase(metadataRepo.fileName));
 			System.out.println(metadataRepo);
 			assertEquals(4027,metadataRepo.recordCount);
 			assertEquals(6608320,metadataRepo.size);
-			assertTrue("application/octet-stream".equalsIgnoreCase(metadataRepo.mimeType));
+			assertTrue("application/warc".equalsIgnoreCase(metadataRepo.mimeType));
 			assertTrue("3a9f2ffac1497c70291d93a8bc86c1469547d8f8".equalsIgnoreCase(metadataRepo.checksumSHA1));
 			assertTrue("c7edbde066e4697b3f2d823ac42c3692".equalsIgnoreCase(metadataRepo.checksumMD5));
-			
+
 			assertTrue("2014-01-19T22:37:40Z".equalsIgnoreCase((String)metadataRepo.getHeaderMap().get("WARC-Date")));
 			assertTrue("ARCHIVEIT-924-QUARTERLY-31501-20140119223740943-00015-wbgrp-crawl051.us.archive.org-6441.warc.gz".equalsIgnoreCase((String)metadataRepo.getHeaderMap().get("WARC-Filename")));
 			assertTrue("application/warc-fields".equalsIgnoreCase((String)metadataRepo.getHeaderMap().get("Content-Type")));


### PR DESCRIPTION
## Why was this change made?
To correctly set the mimetype for a WARC.


## How was this change tested?
Unit test.


## Which documentation and/or configurations were updated?
No


